### PR TITLE
include adaptiveHardThresholding in Python package namespace

### DIFF
--- a/Python/src/screenot/__init__.py
+++ b/Python/src/screenot/__init__.py
@@ -1,0 +1,3 @@
+from .ScreeNOT import adaptiveHardThresholding
+
+__all__ = ['adaptiveHardThresholding']


### PR DESCRIPTION
Quick fix to expose `adaptiveHardThresholding` to the package namespace